### PR TITLE
fix(config): comment out sample settings in sample file

### DIFF
--- a/gitconfig.local.sample
+++ b/gitconfig.local.sample
@@ -1,3 +1,3 @@
 [user]
-    name = USERNAME
-    email = email@example.com
+    #name = USERNAME
+    #email = email@example.com


### PR DESCRIPTION
prevent users from accidently using the example values in the gitconfig
local sample file by commenting them out