### PR TITLE
Script to help notify to mitigate package loss on Node.js update

### DIFF
--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/profile
+++ b/profile
@@ -22,8 +22,9 @@ alias bash-reload="source ~/.profile && printf '=> Terminal profile reset.\n'"
 alias terminal-reload="source ~/.profile && printf '=> Profile reset.\n'"
 alias bash-clear-history="cat /dev/null > ~/.bash_history && history -c && exit"
 alias brewup='brew update; brew upgrade; brew cleanup; brew doctor'
-alias npmup='nvm install-latest-npm; npm update -g'
-alias nodelts='nvm install --lts; nvm use --lts'
+alias npmup='bash ~/.dotfiles/scripts/npm-packages.sh before && nvm install-latest-npm  && npm update -g && bash ~/.dotfiles/scripts/npm-packages.sh after'
+alias nodelts='bash ~/.dotfiles/scripts/npm-packages.sh before && nvm install --lts && nvm use --lts && bash ~/.dotfiles/scripts/npm-packages.sh after'
+alias nodeup=nodelts
 alias pubkey="more ~/.ssh/id_rsa.pub | pbcopy && printf '=> Public key copied to pasteboard.\n'"
 alias eject-all="diskutil eject /Volumes/*;diskutil unmountDisk /Volumes/*"
 

--- a/readme.md
+++ b/readme.md
@@ -133,9 +133,9 @@ These are the commands tht trigger a couple commands to yield a specific result.
 |   `bash-reload`    |   Refresh Shell and reload from ~/.profile with visual confirmation    |
 |   `bash-clear-history`    |   Clears bash history    |
 |   `pubkey`    |   Copy public key to keyboard    |
-|   `brewup`    |   Runs Homebrew updates, does housekeeping and reports on any vunerable packages.    |
-|   `npmup`    |   Uses NVM to update to the latest version of NPM and updates all global packages.    |
-|   `nodelts`    |   Uses NVM to update to the LTS version of Node.js    |
+|   `brewup`    |   Runs Homebrew updates, does housekeeping and reports on any vunerable packages    |
+|   `npmup`    |   Uses NVM to update to the latest version of NPM and updates all global packages, with logging and diff of global NPM packages   |
+|   `nodeup`    |   Uses NVM to update to the LTS version of Node.js, with logging and diff of global NPM packages    |
 |   `eject-all`    |   Eject all devices    |
 
 #### Shortcuts for Common Applications

--- a/scripts/npm-packages.sh
+++ b/scripts/npm-packages.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+RESET='\033[0m'  # Reset color to default
+
+SCRIPTDIR=$(readlink -f $(dirname $0)) # Directory this script is in.
+SCRIPTNAME=$0
+PROJECTROOT=$(readlink -f $SCRIPTDIR/../); # Traverse up one from scripts dir.
+LOGDIR=$PROJECTROOT/logs
+DATESTR=$(date "+%Y-%m-%d")
+NODEV=$(node -v)
+NPMV=$(npm -v)
+LOGFILEPREFIX=$DATESTR-npm-global-packages
+LOGFILEBEFORE=$LOGFILEPREFIX-before.log
+LOGFILEAFTER=$LOGFILEPREFIX-after.log
+
+SCRIPTPOSITION=$1 # Reads the before or after parameter
+
+usage() {
+    cat << EOF >&2
+Usage: $SCRIPTNAME [before|after]
+
+before: Runs the operations before update npm to LTS and updating the gloabl NPM pacakges.
+after: Runs the operations after updates.
+EOF
+  exit 1
+}
+
+case $SCRIPTPOSITION in
+
+  "before")
+        # Count files in log dir.
+        LOGFILESINDIR=$(ls -1 $LOGDIR | grep -i -e '\.log$' | wc -l)
+        # Trim leading and trailing spaces.
+        LOGFILESINDIR="$(echo -e "${LOGFILESINDIR}" | tr -d '[:space:]')"
+
+        # Leaves a 50 log buffer.
+        if [ "$LOGFILESINDIR" -gt 60 ]; then
+            echo -e "${YELLOW}[LOGDIR CHECK]${RESET} $LOGFILESINDIR logs in $LOGDIR - Purging 10 oldest files."
+
+            # Deletes the 10 oldest .log files.
+            # Deleting mor elogs than the script will leave
+            # creates a buffer for the next few runs.
+            ls -1 -t $LOGDIR | grep -i -e '\.log$' | tail -n 10 | xargs -I {} rm "$LOGDIR/{}"
+            
+            echo -e "${YELLOW}[LOGDIR CHECK]${RESET} Done.\n"
+        fi
+
+        # Do not clobber any existing before file because we
+        # want the earliest log of the day to persist for all
+        # later diffs.
+        if test -f $LOGDIR/$LOGFILEBEFORE; then
+            echo "Node.js version: $NODEV"
+            echo "npm version: $NPMV"
+
+            echo -e "${YELLOW}An earlier file already exists of logged npm packages to be used for comparison:${RESET} $LOGDIR/$LOGFILE \n"
+            echo "Current packages:"
+            npm list -g
+          else
+            echo "Node.js version: $NODEV" | tee $LOGDIR/$LOGFILEBEFORE
+            echo "npm version: $NPMV" | tee -a $LOGDIR/$LOGFILEBEFORE
+            npm list -g -pl >> $LOGDIR/$LOGFILEBEFORE
+
+            echo -e "Logged a list of globally installed NPM packages to $LOGDIR/$LOGFILE \n"
+            npm list -g
+        fi
+    ;;
+
+  "after")
+        echo "Node.js version: $NODEV" | tee $LOGDIR/$LOGFILEAFTER
+        echo "npm version: $NPMV" | tee -a $LOGDIR/$LOGFILEAFTER
+        npm list -g -pl >> $LOGDIR/$LOGFILEAFTER
+
+        npm list -g
+        echo -e "Logged a list of globally installed NPM packages to $LOGDIR/$LOGFILE for diff comparison...\n" # -e is necessary to support \n consistently.
+
+        diff --color -u $LOGDIR/$LOGFILEBEFORE $LOGDIR/$LOGFILEAFTER
+
+        echo -e "✅ ${GREEN}Update complete.${RESET} Assess diff (above) to see if it is necessary to reinstall any global packages. Bye."
+    ;;
+
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
Add global npm package logging to `nodeup` (formerly `nodelts`) and `npmup` aliases.

- [x] Readme updated
- [x] Tested

fixes #11