### PR TITLE
feat: Improve Node.js/NVM update workflow with package management

### DIFF
--- a/profile
+++ b/profile
@@ -24,8 +24,9 @@ alias bash-clear-history="cat /dev/null > ~/.bash_history && history -c && exit"
 alias zsh-clear-history="cat /dev/null > $HISTFILE && history -p && exit"
 alias brewup='brew update; brew upgrade; brew cleanup; brew doctor'
 alias npmup='bash ~/.dotfiles/scripts/npm-packages.sh before && nvm install-latest-npm  && npm update -g && bash ~/.dotfiles/scripts/npm-packages.sh after'
-alias nodelts='bash ~/.dotfiles/scripts/npm-packages.sh before && nvm install --lts && nvm use --lts && bash ~/.dotfiles/scripts/npm-packages.sh after'
-alias nodeup=nodelts
+alias nodelts=nodeup
+alias nvmup=nodeup
+alias nodeup='source ~/.dotfiles/scripts/nvm-update.sh'
 alias pubkey="more ~/.ssh/id_rsa.pub | pbcopy && printf '=> Public key copied to pasteboard.\n'"
 alias eject-all="diskutil eject /Volumes/*;diskutil unmountDisk /Volumes/*"
 alias git-prune-branches="git checkout main && git branch --merged main | grep -v '^[ *]*main$' | xargs git branch -d"

--- a/readme.md
+++ b/readme.md
@@ -145,8 +145,8 @@ These are the commands that trigger simple scripts or series of commands to yiel
 |   `zsh-clear-history`    |   Clears zsh history    |
 |   `pubkey`    |   Copy public key to keyboard    |
 |   `brewup`    |   Runs Homebrew updates, does housekeeping and reports on any vulnerable packages    |
-|   `npmup`    |   Uses NVM to update to the latest version of NPM and updates all global packages with scripts to log and compare global npm packages before and after the update  |
-|   `nodeup`    |   Uses NVM to update to the LTS version of Node.js with scripts to log and compare global npm packages before and after the update  |
+|   `npmup`    |   Updates NPM and global packages with before/after diff logging  |
+|   `nodeup`    |   Updates Node.js to LTS, and provides global package reinstall suggestions  |
 |   `eject-all`    |   Eject all devices    |
 |   `git-prune-branches`   |   Prunes (deletes) all local branches that have been merged into `main` after checking out the main branch. |
 

--- a/scripts/npm-packages.sh
+++ b/scripts/npm-packages.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 # ANSI color codes
 RED='\033[0;31m'
@@ -46,7 +48,7 @@ case $SCRIPTPOSITION in
             # Deleting mor elogs than the script will leave
             # creates a buffer for the next few runs.
             ls -1 -t $LOGDIR | grep -i -e '\.log$' | tail -n 10 | xargs -I {} rm "$LOGDIR/{}"
-            
+
             echo -e "${YELLOW}[LOGDIR CHECK]${RESET} Done.\n"
         fi
 
@@ -78,9 +80,19 @@ case $SCRIPTPOSITION in
         npm list -g
         echo -e "Logged a list of globally installed NPM packages to $LOGDIR/$LOGFILE for diff comparison...\n" # -e is necessary to support \n consistently.
 
-        diff --color -u $LOGDIR/$LOGFILEBEFORE $LOGDIR/$LOGFILEAFTER
+        git diff --color -u $LOGDIR/$LOGFILEBEFORE $LOGDIR/$LOGFILEAFTER
 
-        echo -e "✅ ${GREEN}Update complete.${RESET} Assess diff (above) to see if it is necessary to reinstall any global packages. Bye."
+        echo -e ""
+
+        echo -e "✅ ${GREEN}npm update complete.${RESET} Assess diff (above) to see if it is necessary to reinstall any global packages."
+
+        NVMLATEST=$(nvm ls-remote --lts --no-colors | tail -1 | sed -E 's/.*(v([0-9]+\.){2,}[0-9]+).*/\1/')
+
+        if [[ "$NODEV" != "$NVMLATEST" ]]; then
+            echo -e "👾 A more recent version of Node has been detected (${NVMLATEST}). Run nodeup to update."
+        fi
+
+        echo -e "Bye."
     ;;
 
   *)

--- a/scripts/nvm-update.sh
+++ b/scripts/nvm-update.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+NODEV=$(node -v)
+NVMLATEST=$(nvm ls-remote --lts --no-colors | tail -1 | sed -E 's/.*(v([0-9]+\.){2,}[0-9]+).*/\1/')
+
+if [[ "$NODEV" == "$NVMLATEST" ]]; then
+    echo -e "👾 Node is at the latest LTS (${NVMLATEST}). No update to do."
+    echo -e "Bye"
+    exit;
+fi
+
+# Collect the list of globally installed npm packages (excluding 'npm' and 'corepack')
+PACKAGE_LIST=$(npm list -g --depth=0 --json | jq -r '.dependencies | to_entries | .[] | select(.key != "npm" and .key != "corepack") | "\(.key) | (\(.value.version))"')
+# Run npm outdated to check for updates
+OUTDATED_LIST=$(npm outdated -g --json)
+
+# Collect the current globally installed package names.
+# Ignores node defaults corepack and npm
+PACKAGE_NAMES=$(npm list -g --depth=0 --json | jq -r '.dependencies | keys[]' | grep -vE '^(corepack|npm)$')
+
+# Update NVM
+echo -e "🤖 Updating to LTS."
+nvm install --lts
+nvm use --lts
+
+NODEV=$(node -v)
+echo -e ""
+echo -e "✅ nvm updated to ${NODEV}"
+echo -e ""
+
+# Output the list of globally installed packages and their versions
+echo -e "The following npm packages were previously installed globally, use the provided command to reinstall them."
+echo -e ""
+
+# Loop through each package and check for updates
+while IFS= read -r line; do
+    PACKAGE_NAME=$(echo "$line" | sed 's/ (\(.*\))/\1/; s/ .*//')  # Extract package name
+    CURRENT_VERSION=$(echo "$line" | sed 's/.* (\(.*\))/\1/')  # Extract version
+
+    # Check if the package is outdated
+    OUTDATED_VERSION=$(echo "$OUTDATED_LIST" | jq -r --arg pkg "$PACKAGE_NAME" '.[$pkg].current // empty')
+
+    if [[ -n "$OUTDATED_VERSION" && "$OUTDATED_VERSION" != "$CURRENT_VERSION" ]]; then
+        # If the version is outdated, add a * next to it
+        echo "$PACKAGE_NAME ($CURRENT_VERSION) *has update"
+    else
+        # If not outdated, just display the package name and version
+        echo "$PACKAGE_NAME ($CURRENT_VERSION)"
+    fi
+done <<< "$PACKAGE_LIST"
+
+# Output the reinstall command
+echo -e ""
+echo -e "To reinstall the packages, use the following command:"
+
+# Remove newlines from PACKAGE_NAMES (convert newlines to spaces)
+PACKAGE_LIST=$(echo "$PACKAGE_NAMES" | tr '\n' ' ')
+echo -e "npm i -g ${PACKAGE_LIST}"
+

--- a/scripts/nvm-update.sh
+++ b/scripts/nvm-update.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+# This script updates the Node.js version to the latest LTS version and
+# provides a list of globally installed npm packages that need to be reinstalled.
+#
+# Preferred Usage:
+#   Run `nodeup` in a terminal - which is an alias for this script.
+#
+# ManualUsage:
+#   nvm-update.sh
+
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 


### PR DESCRIPTION
## Overview

Refactors the `nodeup` alias to provide a smarter Node.js update experience with better global package tracking and reinstallation guidance.

## Key Changes

### New Script: `nvm-update.sh`

- ✨ Adds intelligent version checking - skips update if already on latest LTS
- 📦 Captures global npm packages before Node.js update
- 💡 Provides ready-to-use reinstall command for all global packages
- 🎯 Excludes Node.js defaults (`npm`, `corepack`) from reinstall suggestions

### Alias Improvements

- `nodeup` now uses the new `nvm-update.sh` script
- `nodelts` and `nvmup` aliased to `nodeup` for convenience
- Simplified workflow with clearer output and guidance

### Enhanced `npm-packages.sh`

- 🔧 Ensures NVM is properly loaded before execution
- 🎨 Uses `git diff` for better colored diff output
- 🚀 Detects when newer Node.js LTS version is available after npm updates
- 📝 Improved messaging and user guidance

### Documentation Updates

- Updated README.md with clearer alias descriptions
- Reflects new workflow and functionality